### PR TITLE
Added ID tag to API engines

### DIFF
--- a/app/src/main/java/com/mobilonix/voices/data/api/ApiEngine.java
+++ b/app/src/main/java/com/mobilonix/voices/data/api/ApiEngine.java
@@ -3,6 +3,7 @@ package com.mobilonix.voices.data.api;
 import android.app.DownloadManager;
 
 import com.mobilonix.voices.data.model.Politico;
+import com.mobilonix.voices.representatives.RepresentativesManager;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -16,4 +17,5 @@ public interface ApiEngine {
 
     Request generateRequest(double latitude, double longitude);
     ArrayList<Politico> parseData(String response) throws IOException;
+    RepresentativesManager.RepresentativesType getRepresentativeType();
 }

--- a/app/src/main/java/com/mobilonix/voices/data/api/engines/NycCouncilApi.java
+++ b/app/src/main/java/com/mobilonix/voices/data/api/engines/NycCouncilApi.java
@@ -9,6 +9,7 @@ import com.mobilonix.voices.VoicesApplication;
 import com.mobilonix.voices.data.api.ApiEngine;
 import com.mobilonix.voices.data.api.util.NycCouncilGeoUtil;
 import com.mobilonix.voices.data.model.Politico;
+import com.mobilonix.voices.representatives.RepresentativesManager;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -185,5 +186,10 @@ public class NycCouncilApi implements ApiEngine {
             //TODO handle exception
         }
         return outputStream.toString();
+    }
+
+    @Override
+    public RepresentativesManager.RepresentativesType getRepresentativeType() {
+        return RepresentativesManager.RepresentativesType.COUNCIL_MEMBERS;
     }
 }

--- a/app/src/main/java/com/mobilonix/voices/data/api/engines/StateOpenStatesApi.java
+++ b/app/src/main/java/com/mobilonix/voices/data/api/engines/StateOpenStatesApi.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import com.mobilonix.voices.data.api.ApiEngine;
 import com.mobilonix.voices.data.api.util.UrlGenerator;
 import com.mobilonix.voices.data.model.Politico;
+import com.mobilonix.voices.representatives.RepresentativesManager;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -53,7 +54,7 @@ public class StateOpenStatesApi implements ApiEngine {
     @Override
     public ArrayList<Politico> parseData(String response){
 
-        Log.i("response",response );
+        Log.i("response", response);
 
         ArrayList<Politico> politicos = new ArrayList<>();
 
@@ -84,5 +85,10 @@ public class StateOpenStatesApi implements ApiEngine {
         }
 
         return politicos;
+    }
+
+    @Override
+    public RepresentativesManager.RepresentativesType getRepresentativeType() {
+        return RepresentativesManager.RepresentativesType.STATE_LEGISLATORS;
     }
 }

--- a/app/src/main/java/com/mobilonix/voices/data/api/engines/UsCongressSunlightApi.java
+++ b/app/src/main/java/com/mobilonix/voices/data/api/engines/UsCongressSunlightApi.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import com.mobilonix.voices.data.api.ApiEngine;
 import com.mobilonix.voices.data.api.util.UrlGenerator;
 import com.mobilonix.voices.data.model.Politico;
+import com.mobilonix.voices.representatives.RepresentativesManager;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -93,5 +94,10 @@ public class UsCongressSunlightApi implements ApiEngine {
         }
 
         return politicos;
+    }
+
+    @Override
+    public RepresentativesManager.RepresentativesType getRepresentativeType() {
+        return RepresentativesManager.RepresentativesType.CONGRESS;
     }
 }


### PR DESCRIPTION
you can now call getRepresentativeType() from mApiEngine to find out what kind of data it is holding. I wish I did this earlier.
