### PR TITLE
updated images for local officials to fix crash

### DIFF
--- a/app/src/main/res/raw/nyc_district_data.json
+++ b/app/src/main/res/raw/nyc_district_data.json
@@ -183,7 +183,7 @@
       "phoneNumber": "",
       "email": "rsalamance@council.nyc.gov",
       "party": " ",
-      "photoURLPath": "",
+      "photoURLPath": "http://council.nyc.gov/d17/images/features/rafael-salamanca.jpg",
       "twitter": "",
       "facebook": ""
     },
@@ -403,7 +403,7 @@
       "phoneNumber": "718-642-8664",
       "email": "respinal@council.nyc.gov",
       "party": "D",
-      "photoURLPath": "",
+      "photoURLPath": "http://council.nyc.gov/d37/images/features/EspinalHeadshot.jpg",
       "twitter": "RLEspinal",
       "facebook": "RafaelLEspinaljr"
     },

--- a/app/src/main/res/raw/nyc_district_data.json
+++ b/app/src/main/res/raw/nyc_district_data.json
@@ -403,7 +403,7 @@
       "phoneNumber": "718-642-8664",
       "email": "respinal@council.nyc.gov",
       "party": "D",
-      "photoURLPath": "http://council.nyc.gov/d37/images/features/EspinalHeadshot.jpg",
+      "photoURLPath": "https://www.prlog.org/12280631-council-member-rafael-espinal-jr.jpg",
       "twitter": "RLEspinal",
       "facebook": "RafaelLEspinaljr"
     },


### PR DESCRIPTION
When Photo field is empty for local officials, app crashes. I updated the file with image URLs to fix issue. Affected Districts 17 and 37.
