### PR TITLE
Gutted distance calc, now using PIP algorithm for local officials

### DIFF
--- a/app/src/main/java/com/mobilonix/voices/data/api/util/VoicesGeoUtil.java
+++ b/app/src/main/java/com/mobilonix/voices/data/api/util/VoicesGeoUtil.java
@@ -15,7 +15,7 @@ public class VoicesGeoUtil {
     String mState;
     String mCity;
 
-    public static final int NUMBER_OF_LISTINGS = 5;
+    public static final int NUMBER_OF_LISTINGS = 10;
 
     public VoicesGeoUtil() {}
 


### PR DESCRIPTION
1. Distance calc out, pip algorithm in.
2. I increased the amount of GPS listings returned by the service from 5 to 10. This is just in case one point has incomplete listings in the first five items.
3. I've tested it in various districts and it's working well.
4. The reason you see so many changes is that I added the city JSON file.

Notes:

1. The "API Switch" that occurred added significant tech-debt the API to engine classes, eliminating modularity and tightly coupling them to the REST API.

2. The displaying of local officials is still too tightly coupled with making an HTTP request. The way it's set up currently, the officials won't display unless an HTTP request of some sort has passed successfully. There is no reason to make an HTTP request for locals since none of the data is pulled from the web anymore. Right now a txt file is being pulled from a random website to complete this request and display the local officials.